### PR TITLE
fix: parse url search params in citation links

### DIFF
--- a/lib/parse-links.ts
+++ b/lib/parse-links.ts
@@ -1,4 +1,4 @@
-const regex = /https?:\/\/[\w./%]+/g;
+const regex = /https?:\/\/[\w./%?=&]+/g;
 
 /**
  * Parse links into html anchor elements, handling any trailing punctuation marks.


### PR DESCRIPTION
fixes #174