### PR TITLE
fix: use compact number notation on range slider

### DIFF
--- a/app/(app)/search/_components/search-date-range-slider.tsx
+++ b/app/(app)/search/_components/search-date-range-slider.tsx
@@ -21,7 +21,7 @@ export function SearchDateRangeSlider(props: SearchDateRangeSliderProps): ReactN
 	return (
 		<Slider
 			defaultValue={defaultValue}
-			formatOptions={{ style: "decimal" }}
+			formatOptions={{ notation: "compact" }}
 			maxValue={maxValue}
 			minValue={minValue}
 			onChangeEnd={onChange}


### PR DESCRIPTION
closes #179
