### PR TITLE
fix: fall back to institution name on institution pages

### DIFF
--- a/app/(app)/institutions/[id]/page.tsx
+++ b/app/(app)/institutions/[id]/page.tsx
@@ -48,7 +48,8 @@ export async function generateMetadata(
 		const data = await getInstitution(id);
 
 		const metadata: Metadata = {
-			title: data.expandedName,
+			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+			title: data.expandedName || data.name,
 		};
 
 		return metadata;


### PR DESCRIPTION
this pr uses the institution `name` as a fallback document title, in case the `expandedName` field is empty.

fixes #189
