### PR TITLE
fix: move place map out of disclosure

### DIFF
--- a/app/(app)/places/[id]/_components/point-map.tsx
+++ b/app/(app)/places/[id]/_components/point-map.tsx
@@ -2,9 +2,8 @@
 
 import "leaflet/dist/leaflet.css";
 
-import type { LatLngExpression, Map as LeafletMap } from "leaflet";
-import { type ReactNode, use, useEffect, useRef } from "react";
-import { DisclosureStateContext } from "react-aria-components";
+import type { LatLngExpression } from "leaflet";
+import type { ReactNode } from "react";
 import { CircleMarker, MapContainer, TileLayer } from "react-leaflet";
 
 interface PointMapProps {
@@ -17,22 +16,9 @@ export function PointMap(props: PointMapProps): ReactNode {
 
 	const position: LatLngExpression = [latitude, longitude];
 
-	const mapRef = useRef<LeafletMap | null>(null);
-
-	const context = use(DisclosureStateContext);
-	const isExpanded = context?.isExpanded ?? false;
-
-	useEffect(() => {
-		if (isExpanded) {
-			/** Attempt at fixing https://github.com/acdh-oeaw/viecpro-nuxt/issues/178. */
-			mapRef.current?.invalidateSize();
-		}
-	}, [isExpanded]);
-
 	return (
 		<div className="relative h-96 w-full overflow-hidden rounded-md border border-brand-100">
 			<MapContainer
-				ref={mapRef}
 				center={position}
 				className="absolute inset-0"
 				// scrollWheelZoom={false}

--- a/app/(app)/places/[id]/_components/point-map.tsx
+++ b/app/(app)/places/[id]/_components/point-map.tsx
@@ -17,7 +17,7 @@ export function PointMap(props: PointMapProps): ReactNode {
 	const position: LatLngExpression = [latitude, longitude];
 
 	return (
-		<div className="relative h-96 w-full overflow-hidden rounded-md border border-brand-100">
+		<div className="relative h-96 w-full overflow-hidden rounded-md border border-brand-300">
 			<MapContainer
 				center={position}
 				className="absolute inset-0"

--- a/app/(app)/places/[id]/page.tsx
+++ b/app/(app)/places/[id]/page.tsx
@@ -196,6 +196,15 @@ export default async function PlacePage(props: Readonly<PlacePageProps>): Promis
 
 							<dt className="text-neutral-600">{t("coordinates")}:</dt>
 							<dd>{[data.latitude, data.longitude].filter(isNonEmptyString).join(", ")}</dd>
+
+							{data.latitude != null && data.longitude != null ? (
+								<Fragment>
+									<dt className="sr-only">{t("map")}</dt>
+									<dd>
+										<PointMap latitude={data.latitude} longitude={data.longitude} />
+									</dd>
+								</Fragment>
+							) : null}
 						</dl>
 
 						<Collapsible
@@ -252,17 +261,6 @@ export default async function PlacePage(props: Readonly<PlacePageProps>): Promis
 									);
 								})}
 							</ul>
-						</Collapsible>
-
-						<Collapsible
-							/** Needs to be expanded initially because leaflet does not seem to properly initialize when rendered in a hidden container. */
-							defaultExpanded={data.latitude != null && data.longitude != null}
-							isDisabled={data.latitude == null || data.longitude == null}
-							label={t("map")}
-						>
-							{data.latitude != null && data.longitude != null ? (
-								<PointMap latitude={data.latitude} longitude={data.longitude} />
-							) : null}
 						</Collapsible>
 					</section>
 

--- a/app/(app)/places/[id]/page.tsx
+++ b/app/(app)/places/[id]/page.tsx
@@ -190,7 +190,7 @@ export default async function PlacePage(props: Readonly<PlacePageProps>): Promis
 					<section className="row-span-2 grid content-start gap-y-3">
 						<h2 className="text-2xl text-brand-600">{t("section-data")}</h2>
 
-						<dl className="mb-6 grid grid-cols-[auto_auto] justify-start gap-x-8 gap-y-2">
+						<dl className="mb-6 grid grid-cols-[auto_1fr] justify-start gap-x-8 gap-y-2">
 							<dt className="text-neutral-600">{t("category")}:</dt>
 							<dd>{data.category}</dd>
 
@@ -198,12 +198,12 @@ export default async function PlacePage(props: Readonly<PlacePageProps>): Promis
 							<dd>{[data.latitude, data.longitude].filter(isNonEmptyString).join(", ")}</dd>
 
 							{data.latitude != null && data.longitude != null ? (
-								<Fragment>
+								<div className="col-span-2 h-96">
 									<dt className="sr-only">{t("map")}</dt>
 									<dd>
 										<PointMap latitude={data.latitude} longitude={data.longitude} />
 									</dd>
-								</Fragment>
+								</div>
 							) : null}
 						</dl>
 


### PR DESCRIPTION
this pr moves the point map on place details pages out of the disclosure, and up to "stammdaten".

closes #178 