### PR TITLE
fix: display optional non-court-relation targets

### DIFF
--- a/app/(app)/persons/[id]/_lib/data.ts
+++ b/app/(app)/persons/[id]/_lib/data.ts
@@ -50,7 +50,7 @@ interface PersonDetails extends Person {
 	honoraryTitles: Array<RelationShort> | null;
 	marriagesAndFamilyRelations: Array<Relation> | null;
 	marriedNames: Array<RelationShort> | null;
-	nonCourtFunctions: Array<RelationShort | Relation> | null;
+	nonCourtFunctions: Array<Relation | (RelationShort & { target: null })> | null;
 	notes: string;
 	otherRelationsCourt: Array<RelationShort> | null;
 	personRelationsCourt: Array<Relation> | null;

--- a/app/(app)/persons/[id]/page.tsx
+++ b/app/(app)/persons/[id]/page.tsx
@@ -265,6 +265,7 @@ export default async function PersonPage(props: Readonly<PersonPageProps>): Prom
 									{ value: "nonCourtFunctions", label: t("non-court-functions") },
 									[
 										{ value: "relationType", label: t("relation-type") },
+										{ value: "target.name", label: t("name") },
 										{ value: "startDateWritten", label: t("start-date") },
 										{ value: "endDateWritten", label: t("end-date") },
 									],


### PR DESCRIPTION
this pr displays relation targets for `person.nonCourtRelations` (if they exist) on person details pages.