### PR TITLE
fix: include owner field in courts query fields

### DIFF
--- a/app/(app)/search/courts/_lib/search.ts
+++ b/app/(app)/search/courts/_lib/search.ts
@@ -34,7 +34,7 @@ export interface Court {
 
 const collection = [env.NEXT_PUBLIC_TYPESENSE_COLLECTION_PREFIX, "court"].join("");
 
-const queryFields = ["name"] as const;
+const queryFields = ["name", "owner"] as const;
 const sortFields = ["name", "startDate", "endDate", "owner", "category", "status"] as const;
 const facetFields = ["category", "status"] as const;
 


### PR DESCRIPTION
this includes the `owner` field in the list of query/fulltext fields for courts.

closes #200
