### PR TITLE
fix: person.confession is a string field, not string array

### DIFF
--- a/app/(app)/persons/[id]/_lib/data.ts
+++ b/app/(app)/persons/[id]/_lib/data.ts
@@ -42,7 +42,7 @@ interface PersonDetails extends Person {
 	alternativeDeathDates?: Array<string>;
 	alternativeFirstNames?: Array<string>;
 	alternativeLastNames?: Array<string>;
-	confession?: Array<string>;
+	confession?: string;
 	courtFunctions?: Array<Relation>;
 	duplicates: Array<Relation> | null;
 	firstMarriage?: string;

--- a/app/(app)/persons/[id]/page.tsx
+++ b/app/(app)/persons/[id]/page.tsx
@@ -362,15 +362,15 @@ export default async function PersonPage(props: Readonly<PersonPageProps>): Prom
 								</Fragment>
 							) : null}
 
-							<dt className="text-neutral-600">{t("gender")}:</dt>
-							<dd>{data.gender}</dd>
-
-							{isNonEmptyArray(data.confession) ? (
+							{data.confession ? (
 								<Fragment>
 									<dt className="text-neutral-600">{t("confession")}:</dt>
-									<dd>{format.list(data.confession)}</dd>
+									<dd>{data.confession}</dd>
 								</Fragment>
 							) : null}
+
+							<dt className="text-neutral-600">{t("gender")}:</dt>
+							<dd>{data.gender}</dd>
 						</dl>
 
 						<Collapsible isDisabled={!isNonEmptyArray(data.duplicates)} label={t("duplicates")}>


### PR DESCRIPTION
currently, we incorrectly assumed `person.confession` to be a `Array<string>` field, when actually it is a flat `string` field. this fixes that.

closes #203